### PR TITLE
EBMEDS-860: Logstash part

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       image: "docker.elastic.co/logstash/logstash:${ELK_VERSION}"
       volumes:
         - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml
+        - ./logstash/config/pipelines.yml:/usr/share/logstash/config/pipelines.yml
         - ./logstash/pipeline/:/usr/share/logstash/pipeline/
         - ebmeds-logstash-queue:/usr/share/logstash/data/queue/
       networks:

--- a/logstash/config/logstash.yml
+++ b/logstash/config/logstash.yml
@@ -1,6 +1,4 @@
 http.host: 0.0.0.0
-path.config: /usr/share/logstash/pipeline
 pipeline.batch.delay: 50
 pipeline.batch.size: 125
-pipeline.id: main
 xpack.monitoring.enabled: false

--- a/logstash/config/pipelines.yml
+++ b/logstash/config/pipelines.yml
@@ -1,0 +1,7 @@
+# Log pipeline for ebmeds-logs-* indices
+- pipeline.id: ebmeds-logs
+  path.config: "/usr/share/logstash/pipeline/ebmeds-logs.conf"
+
+# Request pipeline for ebmeds-requests-* indices
+- pipeline.id: ebmeds-requests
+  path.config: "/usr/share/logstash/pipeline/ebmeds-requests.conf"

--- a/logstash/pipeline/ebmeds-logs.conf
+++ b/logstash/pipeline/ebmeds-logs.conf
@@ -11,6 +11,6 @@ filter {
 output {
   elasticsearch {
     hosts => "elasticsearch:9200"
+    index => "ebmeds-logs-%{+YYYY.MM.dd}"
   }
-  stdout {}
 }

--- a/logstash/pipeline/ebmeds-requests.conf
+++ b/logstash/pipeline/ebmeds-requests.conf
@@ -1,0 +1,18 @@
+input {
+  tcp {
+    port => '5005'
+  }
+}
+filter {
+  json {
+    source => "message"
+    remove_field => [ "source", "level", "name", "host", "pid", "hostname", "port", "tags", "message", "@version" ]
+  }
+}
+output {
+  elasticsearch {
+    hosts => "elasticsearch:9200"
+    index => "ebmeds-requests-%{userId}-%{+YYYY.MM.dd}"
+  }
+  stdout {}
+}


### PR DESCRIPTION
[EBMEDS-860](https://jira.duodecim.fi/browse/EBMEDS-860)

_A sysadmin wants to view original request messages in Kibana._

The Logstash part of the pull request that adds a new streaming pipeline to persist API-Gateway incoming requests to the Elasticsearch.

- Adds `pipelines.yml` and `request-pipeline.conf` configuration files.
- Adds streaming and transformation rules for the request pipeline.

***NOTE:*** The API-Gateway part: https://github.com/ebmeds/api-gateway/pull/53