### PR TITLE
Init Redis to a usable state when starting the Swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ebmeds-docker
-Repo that gathers EBMeDS microservices, makes a Docker Swarm, configures and launches them.
+Create a minimal installation of EBMEDS using Docker Swarm in a one-node cluster.
 
 ## Quick start
 
@@ -7,79 +7,10 @@ Repo that gathers EBMeDS microservices, makes a Docker Swarm, configures and lau
 # As a non-root user
 git clone https://github.com/ebmeds/ebmeds-docker.git
 cd ebmeds-docker
-chmod -R 700 .
-chmod -R 750 ./elasticsearch ./kibana ./logstash
-chmod -R 770 ./data ./logstash/queue
-chgrp -R 1000 ./elasticsearch ./data ./logstash ./kibana
+chmod -R 755 .
 
 # You need the proper credentials here
 DOCKER_LOGIN=duodecim+example DOCKER_PASSWORD=somePassword sh start.sh
 ```
-
-## Installation
-
-### Install Docker
-The installation instructions can be found on e.g. [Docker's site](https://www.docker.com). We support version 1.13+.
-
-### Download this repository
-Download the zip file from Github (the "Clone or download" button) or preferrably, if you have Git installed, run the command:
-
-```
-git clone https://github.com/ebmeds/ebmeds-docker.git
-```
-
-## Usage (Docker v1.13+)
-For simply getting up and running with the latest stable version, do the following:
-
-```
-sh start.sh
-# the username and password for the Docker registry will be asked of you,
-# e.g. "duodecim+example" and "somepassword". The service takes a while to
-# start, and is then usable on port 3001.
-sh stop.sh
-```
-
-You can also specify a specific version with
-
-```
-sh start.sh 2.1.0
-```
-
-and you can skip having to enter your Docker registry username and password every time by defining the environment variables:
-
-```
-DOCKER_LOGIN=duodecim+example DOCKER_PASSWORD=somepassword sh start.sh
-```
-
-For more advanced usage, e.g. multi-node clusters, refer to the [Docker documentation](https://docs.docker.com/).
-
-
-## Configuration
-
-Per default the EBMeDS service `api-gateway` listens on port 3001 and is the only access point to the entire swarm. Environment variables can be set per service in the `<image-name>/config.env` file.
-
-## Data storage
-
-The ELK stack used for logging needs to mount a few directories from the host into the containers. Some mount points are only read, i.e. do not need write permissions on the host file system, while others do.
-
-### Read-only mount points
-
-* `./logstash/config` and `./logstash/pipeline` contains the configuration for Logstash, the pipeline config being the more important one for customizing operation.
-* `./kibana/config` holds the Kibana configuration. We run without X-Pack since it's a paid service (this goes for the whole ELK stack).
-
-### Read-write mount points
-
-* `./data` is where the Elasticsearch database will be stored.
-* `./logstash/queue` is where logstash saves in-transit messages that are not yet saved to Elasticsearch
-
-### File permissions
-
-The file permission scheme can be confusing. Docker containers share the Linux kernel with the host operating system. The default user inside a Docker container is user ID 1000, so user ID 1000 on the host needs the proper read/write permissions on the mount points above. See e.g. [the Elasticsearch Docker documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) for examples how to solve this in other ways.
-
-## Advanced usage
-
-There are many advanced features of Docker that can be used to make the service more failsafe. This mostly applies to how the data in the Elastic stack is stored and backed up. Please refer to the Elastic stack documentation for details on this.
-
-## Verifying the installation
-
-TODO
+## Detailed instructions
+Please see the installation instructions at [](https://ebmeds.github.io/docs/installation/)

--- a/config.env
+++ b/config.env
@@ -12,9 +12,9 @@ LOG_LEVEL=info
 # Elastic stack configuration
 #############################
 
-# Uncomment if you want to get rid of all X-Pack features, default is "trial" which requires payment after 30 days (although the degraded service in an unpaid X-Pack seems quite usable.)
-# xpack.license.self_generated.type=basic
-xpack.security.enabled=true
+# This needs to be changed if you want more advanced (and paid-for) Elasticsearch features
+xpack.license.self_generated.type=basic
+xpack.security.enabled=false
 xpack.monitoring.enabled=false
 xpack.graph.enabled=false
 xpack.watcher.enabled=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - ./config.env
     deploy:
       mode: replicated
-      replicas: 4
+      replicas: 2
 
   caregap:
     # listens internally on port 3006 per default and we expose the port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: "quay.io/duodecim/ebmeds-api-gateway:${EBMEDS_VERSION}"
     env_file:
       - ./config.env
+    volumes:
+      - ./users.json:/app/resource/users.json
     ports:
       - 3001:3001
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       replicas: 1 # should be enough
 
   logstash:
-      # listens internally on port 5000 for tcp input per default
+      # listens internally on ports 5000 and 5005 for tcp input per default
       image: "docker.elastic.co/logstash/logstash:${ELK_VERSION}"
       volumes:
         - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 EBMEDS_VERSION=${1:-latest}
 ELK_VERSION=6.2.4
-REDIS_VERSION=4-alpine
+REDIS_VERSION=5-alpine
 
 if [ "$1" = "--help" ]; then
   echo "Usage: sh start.sh [version]";
@@ -42,3 +42,16 @@ echo "Using ELK_VERSION='$ELK_VERSION'..."
 
 EBMEDS_VERSION=$EBMEDS_VERSION ELK_VERSION=$ELK_VERSION REDIS_VERSION=$REDIS_VERSION \
   docker stack deploy --with-registry-auth --compose-file docker-compose.yml ebmeds
+
+echo '##################################################'
+echo '# Attempting to run Redis fix command in 5 seconds.'
+echo '# If the service is not running, run manually the command'
+echo '#'
+echo '# docker exec $(docker ps --filter "name=ebmeds_redis" --format "{{.ID}}") sh -c "yes yes | redis-cli --cluster fix localhost:6379"'
+echo '#'
+echo '# from your command line.'
+echo '###################################################'
+sleep 5
+
+# Redis makes it hard for us to run a cluster with a single node, these commands forcefully allocate slots to the one node we have
+docker exec $(docker ps --filter "name=ebmeds_redis" --format "{{.ID}}") sh -c "yes yes | redis-cli --cluster fix localhost:6379"

--- a/start.sh
+++ b/start.sh
@@ -37,6 +37,9 @@ if [ "$(docker info --format '{{.Swarm.LocalNodeState}}')" = "inactive" ]; then
   docker swarm init
 fi;
 
+echo "Attempting to set vm.max_map_count (Elasticsearch wants it)"
+sysctl -w vm.max_map_count=262144
+
 echo "Using EBMEDS_VERSION='$EBMEDS_VERSION'..."
 echo "Using ELK_VERSION='$ELK_VERSION'..."
 

--- a/start.sh
+++ b/start.sh
@@ -42,13 +42,17 @@ sysctl -w vm.max_map_count=262144
 
 echo "Using EBMEDS_VERSION='$EBMEDS_VERSION'..."
 echo "Using ELK_VERSION='$ELK_VERSION'..."
+echo "Using REDIS_VERSION='$REDIS_VERSION'..."
+
+# Pull redis so we have it on disk and can start it immediately when "docker stack deploy" is run
+docker pull redis:$REDIS_VERSION
 
 EBMEDS_VERSION=$EBMEDS_VERSION ELK_VERSION=$ELK_VERSION REDIS_VERSION=$REDIS_VERSION \
   docker stack deploy --with-registry-auth --compose-file docker-compose.yml ebmeds
 
 echo '##################################################'
 echo '# Attempting to run Redis fix command in 5 seconds.'
-echo '# If the service is not running, run manually the command'
+echo '# If the command fails, run manually the command'
 echo '#'
 echo '# docker exec $(docker ps --filter "name=ebmeds_redis" --format "{{.ID}}") sh -c "yes yes | redis-cli --cluster fix localhost:6379"'
 echo '#'

--- a/users.json
+++ b/users.json
@@ -1,0 +1,4 @@
+{
+  "defaultConfig": {},
+  "userMode": "single"
+}


### PR DESCRIPTION
Redis makes life difficult if we are running a cluster with only one node, added some extra init commands to force it. This is done instead of having a switch in the code to run in "normal" or "cluster" mode.

UPDATE: Also added the mounting of `users.json` into api-gateway, with a very minimal (basically empty) config file.