### PR TITLE
Add CMR to docker stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,15 @@ services:
       mode: replicated
       replicas: 1
 
+  cmr:
+    # listens internally on port 3003 by default
+    image: "quay.io/duodecim/ebmeds-cmr:${EBMEDS_VERSION}"
+    networks:
+      - ebmedsnet
+    deploy:
+      mode: replicated
+      replicas: 1
+
 volumes:
   ebmeds-logstash-queue:
   ebmeds-elasticsearch-data:


### PR DESCRIPTION
Add CMR to EBMEDS-docker stack.

**Merge [CMR side](https://github.com/ebmeds/comprehensive-medication-review/pull/80) and [API-gateway side](https://github.com/ebmeds/api-gateway/pull/59) first** (and test after other merged)

**Note:** Pull request to master, apparently `dev`-branch not used similarly to other repos? At least it seems to be behind master