### PR TITLE
Rename public host URL env-variable, deprecate old

### DIFF
--- a/config.env
+++ b/config.env
@@ -2,8 +2,11 @@
 # EBMEDS configuration
 ######################
 
-# Set this to whatever URL you will be hosting EBMeDS on, e.g. http://example.com/ebmeds or https://example.com:3001
+# Set this to whatever URL you will be hosting EBMeDS on. Deprecated, use EBMEDS_API_URL instead
 EBMEDS_CAREGAP_API_URL=
+
+# Set this to whatever URL you will be hosting EBMeDS on, e.g. http://example.com/ebmeds or https://example.com:3001
+EBMEDS_API_URL=
 
 # The log level for internal services, can be debug, info, warn, error
 EBMEDS_LOG_LEVEL=info


### PR DESCRIPTION
Add new `EBMEDS_API_URL`, deprecate `EBMEDS_CAREGAP_API_URL` (will be removed after changes done in caregap + most likely have to info users).

This rename is due to CMR also needing this env-variable.