### PR TITLE
EBMEDS-957: performance monitoring for sirppi

### DIFF
--- a/apm/apm-server.yml
+++ b/apm/apm-server.yml
@@ -1,0 +1,9 @@
+apm-server:
+  host: 0.0.0.0:8200
+
+output:
+  elasticsearch:
+    hosts: http://elasticsearch:9200
+
+setup.kibana:
+  host: http://kibana:5601

--- a/config.env
+++ b/config.env
@@ -25,6 +25,10 @@ xpack.monitoring.enabled=false
 xpack.graph.enabled=false
 xpack.watcher.enabled=false
 
+# Determine whether the performance metrics are collected
+# from api-gateway, engine, clinical-datastore and format-converter or not.
+ELASTIC_APM_ACTIVE=true
+
 # set the below values to 50% of your server RAM, and for best performance
 # turn off swapping on the host OS
 ES_JAVA_OPTS=-Xms2g -Xmx2g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,18 @@ services:
         mode: replicated
         replicas: 1
 
+  apm:
+    # listens internally on ports 8200 by default
+    image: "docker.elastic.co/apm/apm-server:${ELK_VERSION}"
+    volumes:
+      - ./apm/apm-server.yml:/usr/share/apm-server/apm-server.yml
+      - ebmeds-apm-data:/usr/share/apm-server/data
+    networks:
+      - ebmedsnet
+    deploy:
+      mode: replicated
+      replicas: 1
+
   redis:
     # listens internally on port 6379 by default
     image: "redis:${REDIS_VERSION}"
@@ -135,6 +147,7 @@ services:
       replicas: 1
 
 volumes:
+  ebmeds-apm-data:
   ebmeds-logstash-queue:
   ebmeds-elasticsearch-data:
   ebmeds-redis-data:


### PR DESCRIPTION
[EBMEDS-957](https://jira.duodecim.fi/browse/EBMEDS-957)

This pull request adds an Elastic APM service to the EBMEDS infrastructure. To provide the APM service to the ODA2, we have to communicate with the cloud team.

For now, collecting performance metrics only from `api-gateway`, `engine`, `clinical-datastore` and `format-converter`.

See also:
- api-gateway: https://github.com/ebmeds/api-gateway/pull/72
- engine: https://github.com/ebmeds/engine/pull/236
- clinical-datastore: https://github.com/ebmeds/clinical-datastore/pull/75
- format-converter: https://github.com/ebmeds/format-converter/pull/77