### PR TITLE
Docker fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.3"
 
 services:
   api-gateway:
@@ -46,6 +46,7 @@ services:
     deploy:
       mode: replicated
       replicas: 1
+      endpoint_mode: dnsrr
 
   format-converter:
     # listens internally on port 3005 per default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,8 @@ services:
     image: "quay.io/duodecim/ebmeds-cmr:${EBMEDS_VERSION}"
     networks:
       - ebmedsnet
+    env_file:
+      - ./config.env
     deploy:
       mode: replicated
       replicas: 1


### PR DESCRIPTION
No jira-ticket for this one, have been meaning to done this way earlier.

- set clinical-datastore endpoint_mode to `dnsrr`. This will have performance benefits in environments where the customer will directly just run the swarm/compose. Needs to update compose version from `3` -> `3.3` to allow endpoint_mode support
- Add config.env for CMR. This is already passed to CMR in the current production environment, but has been forgotten here. CMR does not get the needed environment values when run with current configuration