### PR TITLE
EBMEDS-1202: persist requested reminders to the elastic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
         - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml
         - ./logstash/config/pipelines.yml:/usr/share/logstash/config/pipelines.yml
         - ./logstash/pipeline/:/usr/share/logstash/pipeline/
+        - ./logstash/ruby/:/usr/share/logstash/ruby/
         - ebmeds-logstash-queue:/usr/share/logstash/data/queue/
       networks:
         - ebmedsnet

--- a/kibana/view/kibana-reminder-dashboard.json
+++ b/kibana/view/kibana-reminder-dashboard.json
@@ -1,0 +1,18 @@
+[
+  {
+    "_id": "33fc2260-c268-11e9-b13d-1f9f01a6655c",
+    "_type": "dashboard",
+    "_source": {
+      "title": "Reminder",
+      "hits": 0,
+      "description": "Visualisation representation of the returnable reminders.",
+      "panelsJSON": "[{\"panelIndex\":\"1\",\"gridData\":{\"x\":0,\"y\":4,\"w\":4,\"h\":3,\"i\":\"1\"},\"embeddableConfig\":{\"vis\":{\"legendOpen\":true},\"spy\":null},\"id\":\"71a14d40-c266-11e9-bfe2-5bfa710f0c01\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"2\",\"gridData\":{\"x\":4,\"y\":4,\"w\":4,\"h\":3,\"i\":\"2\"},\"id\":\"e4c84160-c267-11e9-b13d-1f9f01a6655c\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"3\",\"gridData\":{\"x\":8,\"y\":0,\"w\":4,\"h\":4,\"i\":\"3\"},\"id\":\"71b1e7b0-c269-11e9-b13d-1f9f01a6655c\",\"type\":\"visualization\",\"version\":\"6.2.4\",\"embeddableConfig\":{\"vis\":{\"legendOpen\":true}}},{\"panelIndex\":\"4\",\"gridData\":{\"x\":0,\"y\":0,\"w\":8,\"h\":4,\"i\":\"4\"},\"embeddableConfig\":{\"vis\":{\"legendOpen\":false}},\"id\":\"d08e0100-c26a-11e9-b13d-1f9f01a6655c\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"5\",\"gridData\":{\"x\":8,\"y\":4,\"w\":4,\"h\":3,\"i\":\"5\"},\"id\":\"63d0b6f0-c26c-11e9-b13d-1f9f01a6655c\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"6\",\"gridData\":{\"x\":0,\"y\":10,\"w\":4,\"h\":3,\"i\":\"6\"},\"id\":\"f6b5b1f0-c26c-11e9-b13d-1f9f01a6655c\",\"type\":\"visualization\",\"version\":\"6.2.4\",\"embeddableConfig\":{\"spy\":null}},{\"panelIndex\":\"7\",\"gridData\":{\"x\":4,\"y\":7,\"w\":4,\"h\":3,\"i\":\"7\"},\"id\":\"8a9d76f0-c26d-11e9-b13d-1f9f01a6655c\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"8\",\"gridData\":{\"x\":4,\"y\":10,\"w\":4,\"h\":3,\"i\":\"8\"},\"id\":\"23f3eb90-c26e-11e9-b13d-1f9f01a6655c\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"9\",\"gridData\":{\"x\":8,\"y\":7,\"w\":4,\"h\":3,\"i\":\"9\"},\"id\":\"e4c84160-c267-11e9-b13d-1f9f01a6655c\",\"type\":\"visualization\",\"version\":\"6.2.4\"},{\"panelIndex\":\"10\",\"gridData\":{\"x\":0,\"y\":7,\"w\":4,\"h\":3,\"i\":\"10\"},\"id\":\"99422c80-c26f-11e9-b13d-1f9f01a6655c\",\"type\":\"visualization\",\"version\":\"6.2.4\"}]",
+      "optionsJSON": "{\"darkTheme\":false,\"hidePanelTitles\":false,\"useMargins\":true}",
+      "version": 1,
+      "timeRestore": false,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[],\"highlightAll\":true,\"version\":true}"
+      }
+    }
+  }
+]

--- a/kibana/view/kibana-reminder-visualizes.json
+++ b/kibana/view/kibana-reminder-visualizes.json
@@ -1,0 +1,128 @@
+[
+  {
+    "_id": "d08e0100-c26a-11e9-b13d-1f9f01a6655c",
+    "_type": "visualization",
+    "_source": {
+      "title": "Reminder Date Histogram",
+      "visState": "{\"title\":\"Reminder Date Histogram\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Reminder\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"interval\":\"m\",\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{},\"customLabel\":\"Time\"}}]}",
+      "uiStateJSON": "{\"vis\":{\"legendOpen\":true}}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+      }
+    }
+  },
+  {
+    "_id": "8a9d76f0-c26d-11e9-b13d-1f9f01a6655c",
+    "_type": "visualization",
+    "_source": {
+      "title": "Contraindication's Reminder",
+      "visState": "{\"title\":\"Contraindication's Reminder\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"text.keyword\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":true,\"missingBucketLabel\":\"Missing\",\"size\":10000,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"text\"}}]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"filter\":[{\"meta\":{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"negate\":false,\"disabled\":false,\"alias\":\"Contraindication's Reminder\",\"type\":\"phrase\",\"key\":\"group.keyword\",\"value\":\"Contraindications\",\"params\":{\"query\":\"Contraindications\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"group.keyword\":{\"query\":\"Contraindications\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+      }
+    }
+  },
+  {
+    "_id": "e4c84160-c267-11e9-b13d-1f9f01a6655c",
+    "_type": "visualization",
+    "_source": {
+      "title": "Indication's Reminder",
+      "visState": "{\"title\":\"Indication's Reminder\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"text.keyword\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":true,\"missingBucketLabel\":\"Missing\",\"size\":10000,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"text\"}}]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"filter\":[{\"meta\":{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"negate\":false,\"disabled\":false,\"alias\":\"Indication's reminder\",\"type\":\"phrase\",\"key\":\"group.keyword\",\"value\":\"Indications\",\"params\":{\"query\":\"Indications\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"group.keyword\":{\"query\":\"Indications\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+      }
+    }
+  },
+  {
+    "_id": "f6b5b1f0-c26c-11e9-b13d-1f9f01a6655c",
+    "_type": "visualization",
+    "_source": {
+      "title": "Gravidity's Reminder",
+      "visState": "{\"title\":\"Gravidity's Reminder\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"text.keyword\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":true,\"missingBucketLabel\":\"Missing\",\"size\":10000,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"text\"}}]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"alias\":\"Gravidity's Reminder\",\"disabled\":false,\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"key\":\"group.keyword\",\"negate\":false,\"params\":{\"query\":\"Gravidity\",\"type\":\"phrase\"},\"type\":\"phrase\",\"value\":\"Gravidity\"},\"query\":{\"match\":{\"group.keyword\":{\"query\":\"Gravidity\",\"type\":\"phrase\"}}}}],\"query\":{\"language\":\"lucene\",\"query\":\"\"}}"
+      }
+    }
+  },
+  {
+    "_id": "63d0b6f0-c26c-11e9-b13d-1f9f01a6655c",
+    "_type": "visualization",
+    "_source": {
+      "title": "Renbase's Reminder",
+      "visState": "{\"title\":\"Renbase's Reminder\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"text.keyword\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":true,\"missingBucketLabel\":\"Missing\",\"size\":10000,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"text\"}}]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"filter\":[{\"meta\":{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"negate\":false,\"disabled\":false,\"alias\":\"Renbase's Reminder\",\"type\":\"phrase\",\"key\":\"group.keyword\",\"value\":\"Renbase\",\"params\":{\"query\":\"Renbase\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"group.keyword\":{\"query\":\"Renbase\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+      }
+    }
+  },
+  {
+    "_id": "71a14d40-c266-11e9-bfe2-5bfa710f0c01",
+    "_type": "visualization",
+    "_source": {
+      "title": "Script's Reminder",
+      "visState": "{\"aggs\":[{\"enabled\":true,\"id\":\"1\",\"params\":{},\"schema\":\"metric\",\"type\":\"count\"},{\"enabled\":true,\"id\":\"2\",\"params\":{\"customLabel\":\"text\",\"field\":\"text.keyword\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\",\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"size\":10000},\"schema\":\"segment\",\"type\":\"terms\"}],\"params\":{\"addLegend\":true,\"addTooltip\":true,\"isDonut\":true,\"labels\":{\"last_level\":true,\"show\":false,\"truncate\":100,\"values\":true},\"legendPosition\":\"right\",\"type\":\"pie\"},\"title\":\"Script's Reminder\",\"type\":\"pie\"}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"alias\":\"Script's reminder\",\"disabled\":false,\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"key\":\"group.keyword\",\"negate\":false,\"params\":{\"query\":\"Script\",\"type\":\"phrase\"},\"type\":\"phrase\",\"value\":\"Script\"},\"query\":{\"match\":{\"group.keyword\":{\"query\":\"Script\",\"type\":\"phrase\"}}}}],\"query\":{\"language\":\"lucene\",\"query\":\"\"}}"
+      }
+    }
+  },
+  {
+    "_id": "71b1e7b0-c269-11e9-b13d-1f9f01a6655c",
+    "_type": "visualization",
+    "_source": {
+      "title": "Reminder's Group",
+      "visState": "{\"title\":\"Reminder's Group\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"group.keyword\",\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":true,\"missingBucketLabel\":\"Missing\",\"size\":50,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"Group\"}}]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"filter\":[],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+      }
+    }
+  },
+  {
+    "_id": "23f3eb90-c26e-11e9-b13d-1f9f01a6655c",
+    "_type": "visualization",
+    "_source": {
+      "title": "Lactation's Reminder",
+      "visState": "{\"title\":\"Lactation's Reminder\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"text.keyword\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":true,\"missingBucketLabel\":\"Missing\",\"include\":\"\",\"size\":10000,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"text\"}}]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"filter\":[{\"meta\":{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"negate\":false,\"disabled\":false,\"alias\":\"Lactation's Reminder\",\"type\":\"phrase\",\"key\":\"group.keyword\",\"value\":\"Lactation\",\"params\":{\"query\":\"Lactation\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"group.keyword\":{\"query\":\"Lactation\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+      }
+    }
+  },
+  {
+    "_id": "99422c80-c26f-11e9-b13d-1f9f01a6655c",
+    "_type": "visualization",
+    "_source": {
+      "title": "Interaction's Reminder",
+      "visState": "{\"title\":\"Interaction's Reminder\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"text.keyword\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":true,\"missingBucketLabel\":\"Missing\",\"size\":10000,\"order\":\"desc\",\"orderBy\":\"1\",\"customLabel\":\"text\"}}]}",
+      "uiStateJSON": "{}",
+      "description": "",
+      "version": 1,
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"filter\":[{\"meta\":{\"index\":\"30894f50-c253-11e9-bfe2-5bfa710f0c01\",\"negate\":false,\"disabled\":false,\"alias\":\"Interaction's Reminder\",\"type\":\"phrase\",\"key\":\"group.keyword\",\"value\":\"Interactions\",\"params\":{\"query\":\"Interactions\",\"type\":\"phrase\"}},\"query\":{\"match\":{\"group.keyword\":{\"query\":\"Interactions\",\"type\":\"phrase\"}}},\"$state\":{\"store\":\"appState\"}}],\"query\":{\"query\":\"\",\"language\":\"lucene\"}}"
+      }
+    }
+  }
+]

--- a/logstash/config/pipelines.yml
+++ b/logstash/config/pipelines.yml
@@ -5,3 +5,7 @@
 # Request pipeline for ebmeds-requests-* indices
 - pipeline.id: ebmeds-requests
   path.config: "/usr/share/logstash/pipeline/ebmeds-requests.conf"
+
+# Reminders pipeline for ebmeds-reminders-* indices
+- pipeline.id: ebmeds-reminders
+  path.config: "/usr/share/logstash/pipeline/ebmeds-reminders.conf"

--- a/logstash/pipeline/ebmeds-reminders.conf
+++ b/logstash/pipeline/ebmeds-reminders.conf
@@ -1,0 +1,17 @@
+input {
+  tcp {
+    port => '5001'
+  }
+}
+filter {
+  json {
+    source => "message"
+    remove_field => [ "source", "level", "name", "host", "pid", "hostname", "port", "tags", "message", "@version" ]
+  }
+}
+output {
+  elasticsearch {
+    hosts => "elasticsearch:9200"
+    index => "ebmeds-reminders-%{userId}-%{+YYYY.MM.dd}"
+  }
+}

--- a/logstash/pipeline/ebmeds-reminders.conf
+++ b/logstash/pipeline/ebmeds-reminders.conf
@@ -8,10 +8,22 @@ filter {
     source => "message"
     remove_field => [ "source", "level", "name", "host", "pid", "hostname", "port", "tags", "message", "@version" ]
   }
+  split {
+    field => "reminders"
+  }
+  ruby {
+    path => "/usr/share/logstash/ruby/flat-source.rb"
+    script_params => {
+      "source" => "reminders"
+    }
+  }
+  mutate {
+    remove_field => [ "reminders", "@version" ]
+  }
 }
 output {
   elasticsearch {
     hosts => "elasticsearch:9200"
-    index => "ebmeds-reminders-%{userId}-%{+YYYY.MM.dd}"
+    index => "ebmeds-reminders-%{+YYYY.MM.dd}"
   }
 }

--- a/logstash/pipeline/ebmeds-requests.conf
+++ b/logstash/pipeline/ebmeds-requests.conf
@@ -14,5 +14,4 @@ output {
     hosts => "elasticsearch:9200"
     index => "ebmeds-requests-%{userId}-%{+YYYY.MM.dd}"
   }
-  stdout {}
 }

--- a/logstash/ruby/flat-source.rb
+++ b/logstash/ruby/flat-source.rb
@@ -1,0 +1,21 @@
+def register(params)
+  @source = params["source"]
+end
+
+# Move reminder properties to the root-level
+def filter(event)
+  # tag @source_field_not_found when source fields is not present
+  if event.get(@source).nil?
+    event.tag("#{@source}_not_found")
+    return [event]
+  end
+
+  event
+    .get(@source)
+    .each do |k, v|
+      event.set(k, v)
+    end
+
+  # Logstash required filter method to return a list of events.
+  return [event]
+end


### PR DESCRIPTION
[EBMEDS-1202](https://jira.duodecim.fi/browse/EBMEDS-1202)

This pull request adds a new pipeline to stream returnable reminders into Elastic stack. The content of the input stream is a list of returnable reminders. Therefore, it's splitting into a single event and then flattening by the custom filter before persisting.

The view of the usage of the reminders is exported and persisted under the `kibana/view` directory.

See also: https://github.com/ebmeds/engine/pull/250