### PR TITLE
EBMEDS-1204: Add the master-data service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,26 @@ services:
       mode: replicated
       replicas: 1
       endpoint_mode: dnsrr
+    volumes:
+      - ebmeds-master-data-staging:/app/master-data/staging:ro
+      - ebmeds-master-data-version-mapping:/app/master-data/version-mapping:ro
+      - ebmeds-master-data-versions:/app/master-data/versions:ro
+
+  master-data:
+    # by default, listens internally on port 3020
+    image: "quay.io/duodecim/ebmeds-master-data:${EBMEDS_MASTER_DATA_VERSION}"
+    networks:
+      - ebmedsnet
+    env_file:
+      - ./config.env
+    deploy:
+      mode: replicated
+      replicas: 1
+      endpoint_mode: dnsrr
+    volumes:
+      - ebmeds-master-data-staging:/master-data/staging
+      - ebmeds-master-data-version-mapping:/master-data/version-mapping
+      - ebmeds-master-data-versions:/master-data/versions
 
   format-converter:
     # listens internally on port 3005 per default
@@ -150,6 +170,9 @@ services:
       replicas: 1
 
 volumes:
+  ebmeds-master-data-staging:
+  ebmeds-master-data-version-mapping:
+  ebmeds-master-data-versions:
   ebmeds-apm-data:
   ebmeds-logstash-queue:
   ebmeds-elasticsearch-data:

--- a/start.sh
+++ b/start.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 EBMEDS_VERSION=${1:-latest}
+EBMEDS_MASTER_DATA_VERSION=${2:-latest}
 ELK_VERSION=6.2.4
 REDIS_VERSION=5-alpine
 
-if [ "$1" = "--help" ]; then
-  echo "Usage: sh start.sh [version]";
-  echo "version: latest | x.y.z | dev";
+if [[ "$1" = "--help" ]]; then
+  echo "Usage: sh start.sh [ebmeds-version] [master-data-version]";
+  echo "ebmeds-version: latest | x.y.z | dev";
+  echo "master-data-version: latest | x.y.z";
   echo;
   echo "The environment variables DOCKER_LOGIN and DOCKER_PASSWORD can be used to skip having to manually enter the quay.io login info every time."
 exit 0;
@@ -40,12 +42,14 @@ fi;
 echo "Attempting to set vm.max_map_count (Elasticsearch wants it)"
 sysctl -w vm.max_map_count=262144
 
-echo "Using EBMEDS_VERSION='$EBMEDS_VERSION'..."
-echo "Using ELK_VERSION='$ELK_VERSION'..."
-echo "Using REDIS_VERSION='$REDIS_VERSION'..."
+echo "Using EBMEDS_VERSION=${EBMEDS_VERSION}..."
+echo "Using EBMEDS_MASTER_DATA_VERSION=${EBMEDS_MASTER_DATA_VERSION}..."
+echo "Using ELK_VERSION=${ELK_VERSION}..."
+echo "Using REDIS_VERSION=${REDIS_VERSION}..."
 
 # Pull redis so we have it on disk and can start it immediately when "docker stack deploy" is run
-docker pull redis:$REDIS_VERSION
+docker pull redis:${REDIS_VERSION}
 
-EBMEDS_VERSION=$EBMEDS_VERSION ELK_VERSION=$ELK_VERSION REDIS_VERSION=$REDIS_VERSION \
+EBMEDS_VERSION=${EBMEDS_VERSION} EBMEDS_MASTER_DATA_VERSION=${EBMEDS_MASTER_DATA_VERSION} \
+ELK_VERSION=${ELK_VERSION} REDIS_VERSION=${REDIS_VERSION} \
   docker stack deploy --with-registry-auth --compose-file docker-compose.yml ebmeds


### PR DESCRIPTION
[EBMEDS-1204](https://jira.duodecim.fi/browse/EBMEDS-1204)

This pull request adds the `master-data` service and maps the necessary `master-data` into volumes to be shared with the `clinical-datastore`.

Most of the case, there will be no issue with this pattern, but downgrading might be the issue as the persisted `master-data` in the volumes is not synchronised with the `master-data` container. This is easy to automate by deleting the Docker `master-data` volumes before spin-up the swarm.

Master-data change: https://github.com/ebmeds/master-data/pull/3
Clinical-data change: https://github.com/ebmeds/clinical-datastore/pull/82