### PR TITLE
EBMEDS-1242: merge format-converter into api-gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Removed
+[EBMEDS-1242:](https://jira.duodecim.fi/browse/EBMEDS-1242) Removed the format-converter from the docker-compose definition
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,17 +48,6 @@ services:
       replicas: 1
       endpoint_mode: dnsrr
 
-  format-converter:
-    # listens internally on port 3005 per default
-    image: "quay.io/duodecim/ebmeds-format-converter:${EBMEDS_VERSION}"
-    networks:
-      - ebmedsnet
-    env_file:
-      - ./config.env
-    deploy:
-      mode: replicated
-      replicas: 2
-
   caregap:
     # listens internally on port 3006 per default and we expose the port
     image: "quay.io/duodecim/ebmeds-caregap:${EBMEDS_VERSION}"


### PR DESCRIPTION
[EBMEDS-1242](https://jira.duodecim.fi/browse/EBMEDS-1242)

This pull request removes the `format-converter` from the docker-compose definition.

API-gateway changes: https://github.com/ebmeds/api-gateway/pull/85