### PR TITLE
EBMEDS-1192: Remove Redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 [EBMEDS-1242:](https://jira.duodecim.fi/browse/EBMEDS-1242) Removed the format-converter from the docker-compose definition
+[EBMEDS-1192:](https://jira.duodecim.fi/browse/EBMEDS-1192) Removed Redis from docker-swarm
 

--- a/config.env
+++ b/config.env
@@ -11,9 +11,6 @@ EBMEDS_API_URL=
 # The log level for internal services, can be debug, info, warn, error
 EBMEDS_LOG_LEVEL=info
 
-# Set to cluster if wanted (extra configuration also required)
-EBMEDS_REDIS_MODE=single
-
 #############################
 # Elastic stack configuration
 #############################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,19 +135,6 @@ services:
       mode: replicated
       replicas: 1
 
-  redis:
-    # listens internally on port 6379 by default
-    image: "redis:${REDIS_VERSION}"
-    command: redis-server /usr/local/etc/redis/redis.conf
-    volumes:
-      - ebmeds-redis-data:/data
-      - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
-    networks:
-      - ebmedsnet
-    deploy:
-      mode: replicated
-      replicas: 1
-
   cmr:
     # listens internally on port 3003 by default
     image: "quay.io/duodecim/ebmeds-cmr:${EBMEDS_VERSION}"
@@ -166,7 +153,6 @@ volumes:
   ebmeds-apm-data:
   ebmeds-logstash-queue:
   ebmeds-elasticsearch-data:
-  ebmeds-redis-data:
 networks:
   ebmedsnet:
 

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -1,8 +1,0 @@
-# We require redis to run in cluster mode, even if it has only one node
-cluster-enabled no
-
-# Once-per-second AOF mode is good enough for most deployments
-appendonly yes
-appendfsync everysec
-auto-aof-rewrite-percentage 100
-auto-aof-rewrite-min-size 32mb

--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,6 @@
 EBMEDS_VERSION=${1:-latest}
 EBMEDS_MASTER_DATA_VERSION=${2:-latest}
 ELK_VERSION=6.2.4
-REDIS_VERSION=5-alpine
 
 if [[ "$1" = "--help" ]]; then
   echo "Usage: sh start.sh [ebmeds-version] [master-data-version]";
@@ -45,11 +44,7 @@ sysctl -w vm.max_map_count=262144
 echo "Using EBMEDS_VERSION=${EBMEDS_VERSION}..."
 echo "Using EBMEDS_MASTER_DATA_VERSION=${EBMEDS_MASTER_DATA_VERSION}..."
 echo "Using ELK_VERSION=${ELK_VERSION}..."
-echo "Using REDIS_VERSION=${REDIS_VERSION}..."
-
-# Pull redis so we have it on disk and can start it immediately when "docker stack deploy" is run
-docker pull redis:${REDIS_VERSION}
 
 EBMEDS_VERSION=${EBMEDS_VERSION} EBMEDS_MASTER_DATA_VERSION=${EBMEDS_MASTER_DATA_VERSION} \
-ELK_VERSION=${ELK_VERSION} REDIS_VERSION=${REDIS_VERSION} \
+ELK_VERSION=${ELK_VERSION} \
   docker stack deploy --with-registry-auth --compose-file docker-compose.yml ebmeds


### PR DESCRIPTION
Removes Redis from engine as per [EBMEDS-1192](https://jira.duodecim.fi/browse/EBMEDS-1192).

---

- schema changes: https://github.com/ebmeds/schemas/pull/27
- api-gateway changes: https://github.com/ebmeds/api-gateway/pull/86
- engine changes: https://github.com/ebmeds/engine/pull/261