### PR TITLE
EBMEDS-1243: update the elastic stack to the latest minor

### DIFF
--- a/logstash/pipeline/ebmeds-logs.conf
+++ b/logstash/pipeline/ebmeds-logs.conf
@@ -1,6 +1,6 @@
 input {
   tcp {
-    port => '5000'
+    port => "5000"
   }
 }
 filter {

--- a/logstash/pipeline/ebmeds-reminders.conf
+++ b/logstash/pipeline/ebmeds-reminders.conf
@@ -1,6 +1,6 @@
 input {
   tcp {
-    port => '5001'
+    port => "5001"
   }
 }
 filter {

--- a/logstash/pipeline/ebmeds-requests.conf
+++ b/logstash/pipeline/ebmeds-requests.conf
@@ -1,6 +1,6 @@
 input {
   tcp {
-    port => '5005'
+    port => "5005"
   }
 }
 filter {

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 EBMEDS_VERSION=${1:-latest}
 EBMEDS_MASTER_DATA_VERSION=${2:-latest}
-ELK_VERSION=6.2.4
+ELK_VERSION=6.8.3
 
 if [[ "$1" = "--help" ]]; then
   echo "Usage: sh start.sh [ebmeds-version] [master-data-version]";


### PR DESCRIPTION
[EBMEDS-1243](https://jira.duodecim.fi/browse/EBMEDS-1243)

This pull request updates the Elastic stack to the latest minor version. it changes the version number in the `start.sh`. Also, all the breaking changes have been reviewed.

**Related changes:**
api-gateway: https://github.com/ebmeds/api-gateway/pull/90
clinical-datastore: https://github.com/ebmeds/clinical-datastore/pull/83
engine: https://github.com/ebmeds/engine/pull/265

## Elastic stack breaking changes from 6.2 to 6.8
### Elasticsearch
- [x] [Breaking Changes in 6.3](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.3.html)
  - The `elasticsearch` module of the engine required refactoring because the `bulk` thread pool has been renamed to the `write` thread pool.
- [x] [Breaking Changes in 6.4](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.4.html)
  - No action is required.
- [x] [Breaking Changes in 6.5](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.5.html)
  - No action is required.
- [x] [Breaking Changes in 6.6](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.6.html)
  - No action is required.
- [x] [Breaking Changes in 6.7](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.7.html)
  - No action is required.
- [x] [Breaking Changes in 6.8](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.8.html)
  - There are no breaking changes for 6.8.0.

### Kibana
- [x] [Breaking changes in v6.3](https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.3.0.html#breaking-6.3.0)
  - No action is required.
- [x] [Breaking changes in v6.4](https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.4.0.html#breaking-6.4.0)
  - No action is required
- [x] [Breaking changes in v6.6](https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.6.0.html#breaking-6.6.0)
  - No action is required.
- [x] [Breaking Changes in v6.7](https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.7.0.html#breaking-6.7.0)
  - No action is required.

### Logstash
- [x] [Persistent Queue](https://www.elastic.co/guide/en/logstash/6.8/upgrading-logstash-pqs.html)
  - The deployment environments required to be drained the persistent queue before upgrading.

### APM
- [x] [Breaking changes in v6.4](https://www.elastic.co/guide/en/apm/get-started/current/breaking-6.4.0.html)
  - Might need to refresh an APM index pattern.

### APM Agent
- [x] [Upgrade to v2.x](https://www.elastic.co/guide/en/apm/agent/nodejs/current/upgrade-to-v2.html)
  - No additional action is required to update the APM agent to version 2.x.

## Things to resolve after upgrage:
- [x] Could not indexe event to Elasticsearch when sending to `ebmeds-logs-*`:
  - Done in pull request https://github.com/ebmeds/engine/pull/269
```shell
ebmeds_logstash.1.rpb06eid5fl4@summer    | [2019-09-18T15:14:38,035][WARN ][logstash.outputs.elasticsearch] Could not index event to Elasticsearch. {:status=>400, :action=>["index", {:_id=>nil, :_index=>"ebmeds-logs-2019.09.18", :_type=>"doc", :routing=>nil}, #<LogStash::Event:0x7f509adf>], :response=>{"index"=>{"_index"=>"ebmeds-logs-2019.09.18", "_type"=>"doc", "_id"=>"DnbwRG0BbY7MbrsYi18-", "status"=>400, "error"=>{"type"=>"mapper_parsing_exception", "reason"=>"failed to parse field [body.keys] of type [text] in document with id 'DnbwRG0BbY7MbrsYi18-'", "caused_by"=>{"type"=>"illegal_state_exception", "reason"=>"Can't get text on a START_OBJECT at 1:138"}}}}}
``` 
 - Logstash expecting that the `body.keys` field type is a text but found a type of array, therefore the parsing failed. Solution for this issue is to send the `keys` field value as text rather than array. Only  `clinical-datastore` are sending this kind of information when `debug` log level is on.