### PR TITLE
EBMEDS-1279: Add DSV service to docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+[EBMEDS-1279:](https://jira.duodecim.fi/browse/EBMEDS-1279) Added dsv service to the docker-compose definition
+
 ### Removed
 [EBMEDS-1242:](https://jira.duodecim.fi/browse/EBMEDS-1242) Removed the format-converter from the docker-compose definition
 [EBMEDS-1192:](https://jira.duodecim.fi/browse/EBMEDS-1192) Removed Redis from docker-swarm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,17 @@ services:
       mode: replicated
       replicas: 1
 
+  dsv:
+    # listens internally on port 3010 by default
+    image: "quay.io/duodecim/ebmeds-diagnosis-specific-view:${EBMEDS_VERSION}"
+    networks:
+      - ebmedsnet
+    env_file:
+      - ./config.env
+    deploy:
+      mode: replicated
+      replicas: 1
+
 volumes:
   ebmeds-master-data-staging:
   ebmeds-master-data-version-mapping:


### PR DESCRIPTION
Adds DSV to the docker-compose definitions as a part of integrating it to the rest of Sirppi. [EBMEDS-1279](https://jira.duodecim.fi/browse/EBMEDS-1279)

---

api-gateway changes: https://github.com/ebmeds/api-gateway/pull/91