### PR TITLE
EBMEDS-1230: merge datastore into engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-[EBMEDS-1279:](https://jira.duodecim.fi/browse/EBMEDS-1279) Added dsv service to the docker-compose definition
+- [EBMEDS-1279:](https://jira.duodecim.fi/browse/EBMEDS-1279) Added dsv service to the docker-compose definition
 
 ### Removed
-[EBMEDS-1242:](https://jira.duodecim.fi/browse/EBMEDS-1242) Removed the format-converter from the docker-compose definition
-[EBMEDS-1192:](https://jira.duodecim.fi/browse/EBMEDS-1192) Removed Redis from docker-swarm
-
+- [EBMEDS-1230:](https://jira.duodecim.fi/browse/EBMEDS-1230) Removed clinical-datastore from the stack
+- [EBMEDS-1242:](https://jira.duodecim.fi/browse/EBMEDS-1242) Removed the format-converter from the docker-compose definition
+- [EBMEDS-1192:](https://jira.duodecim.fi/browse/EBMEDS-1192) Removed Redis from docker-swarm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     deploy:
       mode: replicated
       replicas: 4
+      endpoint_mode: dnsrr
       restart_policy:
         condition: on-failure
         delay: 2s
@@ -35,18 +36,6 @@ services:
         delay: 10s
         failure_action: continue
         max_failure_ratio: 0.3
-
-  clinical-datastore:
-    # listens internally on port 3004 per default
-    image: "quay.io/duodecim/ebmeds-clinical-datastore:${EBMEDS_VERSION}"
-    networks:
-      - ebmedsnet
-    env_file:
-      - ./config.env
-    deploy:
-      mode: replicated
-      replicas: 1
-      endpoint_mode: dnsrr
     volumes:
       - ebmeds-master-data-staging:/app/master-data/staging:ro
       - ebmeds-master-data-version-mapping:/app/master-data/version-mapping:ro


### PR DESCRIPTION
[EBMEDS-1230](https://jira.duodecim.fi/browse/EBMEDS-1230)

This pull request removes the `clinical-datastore` service from the docker-compose description.

See related engine change: https://github.com/ebmeds/engine/pull/267