### PR TITLE
EBMEDS-1319: add package.json to support the Sirppi release-script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [EBMEDS-1279:](https://jira.duodecim.fi/browse/EBMEDS-1279) Added dsv service to the docker-compose definition
+- [EBMEDS-1319:](https://jira.duodecim.fi/browse/EBMEDS-1319) Added the package.json that is required by the Sirppi release-script
 
 ### Removed
 - [EBMEDS-1230:](https://jira.duodecim.fi/browse/EBMEDS-1230) Removed clinical-datastore from the stack

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "ebmeds-docker",
+  "version": "2.3.13",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ebmeds-docker",
+  "version": "2.3.13",
+  "description": "This file is required by the Sirppi release-script."
+}


### PR DESCRIPTION

This pull request adds the `package.json` to support the Sirppi release-script. Also, tagged the latest workable version with the current (v2.3.13) release of the EBMEDS.

See the related changes: https://github.com/ebmeds/util/pull/21