### PR TITLE
Changed index to be generated once a month instead of daily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [EBMEDS-1351:](https://jira.duodecim.fi/browse/EBMEDS-1351) Changed elasticsearch indices to be monthly instead of daily.
+
 ### Added
 - [EBMEDS-1279:](https://jira.duodecim.fi/browse/EBMEDS-1279) Added dsv service to the docker-compose definition
 - [EBMEDS-1319:](https://jira.duodecim.fi/browse/EBMEDS-1319) Added the package.json that is required by the Sirppi release-script

--- a/logstash/pipeline/ebmeds-logs.conf
+++ b/logstash/pipeline/ebmeds-logs.conf
@@ -11,6 +11,6 @@ filter {
 output {
   elasticsearch {
     hosts => "elasticsearch:9200"
-    index => "ebmeds-logs-%{+YYYY.MM.dd}"
+    index => "ebmeds-logs-%{+YYYY.MM}"
   }
 }

--- a/logstash/pipeline/ebmeds-reminders.conf
+++ b/logstash/pipeline/ebmeds-reminders.conf
@@ -24,6 +24,6 @@ filter {
 output {
   elasticsearch {
     hosts => "elasticsearch:9200"
-    index => "ebmeds-reminders-%{+YYYY.MM.dd}"
+    index => "ebmeds-reminders-%{+YYYY.MM}"
   }
 }

--- a/logstash/pipeline/ebmeds-requests.conf
+++ b/logstash/pipeline/ebmeds-requests.conf
@@ -12,6 +12,6 @@ filter {
 output {
   elasticsearch {
     hosts => "elasticsearch:9200"
-    index => "ebmeds-requests-%{userId}-%{+YYYY.MM.dd}"
+    index => "ebmeds-requests-%{userId}-%{+YYYY.MM}"
   }
 }


### PR DESCRIPTION
Changed index frequency to be monthly instead of daily. Old indices should be archived, but that will be dealt with in a separate, less urgent ticket.

https://jira.duodecim.fi/browse/EBMEDS-1351