### PR TITLE
EBMEDS-1450: elastic stack major version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- [EBMEDS-1450:](https://jira.duodecim.fi/browse/EBMEDS-1450) Upgraded the Elastic stack version to v7.6.0
+
 ## V2.4.0 - 2019-11-04
 
 - [EBMEDS-1373:](https://jira.duodecim.fi/browse/EBMEDS-1373) Changed elasticsearch indices to be monthly instead of daily.

--- a/config.env
+++ b/config.env
@@ -15,12 +15,8 @@ EBMEDS_LOG_LEVEL=info
 # Elastic stack configuration
 #############################
 
-# This needs to be changed if you want more advanced (and paid-for) Elasticsearch features
-xpack.license.self_generated.type=basic
-xpack.security.enabled=false
-xpack.monitoring.enabled=false
-xpack.graph.enabled=false
-xpack.watcher.enabled=false
+# This needs to be changed if you want more advanced Elasticsearch features
+discovery.type=single-node
 
 # Determine whether the performance metrics are collected
 # from api-gateway, engine, clinical-datastore and format-converter or not.

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -1,5 +1,3 @@
----
 server.name: ebmeds-kibana
-server.host: "0"
-#server.basePath: "/kibana"
-elasticsearch.url: http://elasticsearch:9200
+server.host: "0.0.0.0"
+elasticsearch.hosts: ["http://elasticsearch:9200"]

--- a/logstash/config/logstash.yml
+++ b/logstash/config/logstash.yml
@@ -1,4 +1,3 @@
 http.host: 0.0.0.0
 pipeline.batch.delay: 50
 pipeline.batch.size: 125
-xpack.monitoring.enabled: false

--- a/logstash/pipeline/ebmeds-requests.conf
+++ b/logstash/pipeline/ebmeds-requests.conf
@@ -12,6 +12,6 @@ filter {
 output {
   elasticsearch {
     hosts => "elasticsearch:9200"
-    index => "ebmeds-requests-%{userId}-%{+YYYY.MM}"
+    index => "ebmeds-requests-%{+YYYY.MM}"
   }
 }

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 EBMEDS_VERSION=${1:-latest}
 EBMEDS_MASTER_DATA_VERSION=${2:-latest}
-ELK_VERSION=6.8.3
+ELK_VERSION=7.6.0
 
 if [[ "$1" = "--help" ]]; then
   echo "Usage: sh start.sh [ebmeds-version] [master-data-version]";


### PR DESCRIPTION
### [EBMEDS-1450](https://jira.duodecim.fi/browse/EBMEDS-1450)

This pull request updates the Elastic to the current latest version (7.6.0) and simplified the `ebmeds-requests-*` Elasticsearch index name. No actionable modifications are required to the EBMEDS to operate with the latest changed Elastic stack.

Before upgrading the existing EBMEDS installation to this current version (7.6.0), make sure that the installed Elastic stack version is **6.8.x**.

More details about upgrading: https://www.elastic.co/guide/en/elastic-stack/7.6/upgrading-elastic-stack.html

**See the related changes:**
- ebmeds-docker: https://github.com/ebmeds/ebmeds-docker/pull/23
- ebmeds-kubernetes: https://github.com/ebmeds/ebmeds-kubernetes/pull/3