### PR TITLE
EBMEDS-1374: ebmeds indices log rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [EBMEDS-1450:](https://jira.duodecim.fi/browse/EBMEDS-1450) Upgraded the Elastic stack version to v7.6.0
 
+### Added
+- [EBMEDS-1374:](https://jira.duodecim.fi/browse/EBMEDS-1374) Added index lifecycle management for the EBMEDS indices
+
 ## V2.4.0 - 2019-11-04
 
 - [EBMEDS-1373:](https://jira.duodecim.fi/browse/EBMEDS-1373) Changed elasticsearch indices to be monthly instead of daily.

--- a/README.md
+++ b/README.md
@@ -82,3 +82,144 @@ Assuming that the path, as mentioned earlier, is our Logstash volume path. Navig
 This gives recursively read, write, execute rights to the owner, group and other to all EBMEDS volumes. This concluded the deployment of the EBMEDS Docker swarm.
 
 It's also worthy to mention that EBMEDS services, e.g. `api-gateway` and `clinical-datastore`, environment variables can be overridden in `config.env` configuration which resides in the project root. Some of the environment variables are global and shared between the EBMEDS Docker services. Such environment variables are e.g. `ELASTIC_APM_ACTIVE` and `EBMEDS_LOG_LEVEL`. Overriding the shared environment variable affect all the services that are using the shared variables.
+
+## Index Lifecycle Management
+This operation was carried out in Elastic stack version 7.6.0 – current release at the time.
+
+EBMEDS sends request payloads, triggered reminders and logs data into specific Elasticsearch indices. These indices are:
+- ebmeds-request-%{YYYY.MM}
+- ebmeds-reminders-%{YYYY.MM}
+- ebmeds-logs-%{YYYY.MM}
+
+The year and month are dynamically formed to the index name, so for example, `ebmeds-request-2020.03` is one possible name and so on. To control these indices in `testing` and `staging` environments, we need to apply Elasticsearch index lifecycle manager, which set the rotate rules for every index.
+
+In the Elasticsearch and for time series indices, the index lifecycle has four stages, and they are:
+- Hot: the index is actively being updated and queried.
+- Warm: the index is no longer being updated, but is still being queried.
+- Cold: the index is no longer being updated and is seldom queried. The information still needs to be searchable, but it is okay if those queries are slower.
+- Delete: the index is no longer needed and can safely be deleted.
+
+#### Use in testing environment
+For the `testing` environment, we get along just with three phases – hot, warm and delete. All the EBMEDS indices are time series. A new entry to the index enters the `hot` stage. After 30 days it will be moved to the `warm` stage and eventually deleted when the data age reached 90 days. Long story short: data that reside in the index longer than 90 days will be deleted.
+
+The index lifecycle management policy needs to be first created into the Elasticsearch before it can be used in the Logstash else an exception is raised. The `ebmeds-policy` can be added into the Elasticsearch followingly:
+
+```bash
+curl -X PUT "http://localhost:9200/_ilm/policy/ebmeds-index-policy?pretty" -H 'Content-Type: application/json' -d'
+{
+  "policy": {
+    "phases": {
+      "hot": {
+      "min_age": "0ms",
+        "actions": {
+          "rollover": {
+            "max_age": "30d"
+          },
+          "set_priority": {
+            "priority": 100
+          }
+        }
+      },
+      "warm": {
+        "min_age": "0ms",
+        "actions": {
+          "allocate": {
+            "number_of_replicas": 1,
+            "include": {},
+            "exclude": {},
+            "require": {}
+          },
+          "forcemerge": {
+            "max_num_segments": 1
+          },
+          "set_priority": {
+            "priority": 50
+          }
+        }
+      },
+      "delete": {
+        "min_age": "60d",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}
+'
+```
+
+#### Advice for staging and production environment
+This index lifecycle policy cannot be used in the `staging` and `production` without modification. The snapshot lifecycle must be configured for the `staging` and `production` environments before we can proceed any further. Make sure that the snapshot lifecycle is working correctly before proceeding. 
+
+Also, make sure that everything is tested in `staging` environment and verified that they work correctly before applying index and snapshot lifecycle to the `production`.
+
+Setting up the snapshot repository is required. Here is a simple skeleton snapshot policy of how to take snapshot daily at midnight.
+
+```json
+{
+  "schedule": "0 0 * * * ?",
+  "name": "ebmeds-snapshot-{now/d}",
+  "repository": "<remember to configure repository>",
+  "config": {
+    "indices": ["*"]
+  }
+}
+```
+For more information about snapshot, please consult the links below.  Let say we name this snapshot lifecycle as `ebmeds-snapshot-policy`.
+
+When the snapshot policy is created and running on the indices, we can proceed to set lifecycle policy for the EBMEDS indices. Following is a recommended policy to use with the EBMEDS, but further modification is required depending on the regulations.
+
+```bash
+curl -X PUT "http://localhost:9200/_ilm/policy/ebmeds-index-policy?pretty" -H 'Content-Type: application/json' -d'
+{
+  "policy": {
+    "phases": {
+      "hot": {
+      "min_age": "0ms",
+        "actions": {
+          "rollover": {
+            "max_age": "30d"
+          },
+          "set_priority": {
+            "priority": 100
+          }
+        }
+      },
+      "warm": {
+        "min_age": "0ms",
+        "actions": {
+          "allocate": {
+            "number_of_replicas": 1,
+            "include": {},
+            "exclude": {},
+            "require": {}
+          },
+          "forcemerge": {
+            "max_num_segments": 1
+          },
+          "set_priority": {
+            "priority": 50
+          }
+        }
+      },
+      "delete": {
+        "min_age": "150d",
+        "actions": {
+	  "wait_for_snapshot" : {
+            "policy": "ebmeds-snapshot-policy"
+          }
+          "delete": {}
+        }
+      }
+    }
+  }
+}
+'
+```
+We now set the `delete` stage to wait for the snapshot to be complete before we can proceed with deletion.
+
+#### Further readings:
+- [Manage the index lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/index-lifecycle-management.html)
+- [Snapshot and restore](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/snapshot-restore.html)
+- [Manage the snapshot lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/snapshot-lifecycle-management.html)

--- a/logstash/pipeline/ebmeds-logs.conf
+++ b/logstash/pipeline/ebmeds-logs.conf
@@ -12,5 +12,13 @@ output {
   elasticsearch {
     hosts => "elasticsearch:9200"
     index => "ebmeds-logs-%{+YYYY.MM}"
+
+    # Set ilm_enabled value to be true
+    # when ebmeds-index-policy exists in Elasticsearch.
+    ilm_enabled => false
+
+    ilm_rollover_alias => "ebmeds-logs"
+    ilm_pattern => "{now{YYYY.MM}}-00001"
+    ilm_policy => "ebmeds-index-policy"
   }
 }

--- a/logstash/pipeline/ebmeds-reminders.conf
+++ b/logstash/pipeline/ebmeds-reminders.conf
@@ -25,5 +25,13 @@ output {
   elasticsearch {
     hosts => "elasticsearch:9200"
     index => "ebmeds-reminders-%{+YYYY.MM}"
+
+    # Set ilm_enabled value to be true
+    # when ebmeds-index-policy exists in Elasticsearch.
+    ilm_enabled => false
+
+    ilm_rollover_alias => "ebmeds-reminders"
+    ilm_pattern => "{now{YYYY.MM}}-00001"
+    ilm_policy => "ebmeds-index-policy"
   }
 }

--- a/logstash/pipeline/ebmeds-requests.conf
+++ b/logstash/pipeline/ebmeds-requests.conf
@@ -13,5 +13,13 @@ output {
   elasticsearch {
     hosts => "elasticsearch:9200"
     index => "ebmeds-requests-%{+YYYY.MM}"
+
+    # Set ilm_enabled value to be true
+    # when ebmeds-index-policy exists in Elasticsearch.
+    ilm_enabled => false
+
+    ilm_rollover_alias => "ebmeds-requests"
+    ilm_pattern => "{now{YYYY.MM}}-00001"
+    ilm_policy => "ebmeds-index-policy"
   }
 }


### PR DESCRIPTION
### [EBMEDS-1374](https://jira.duodecim.fi/browse/EBMEDS-1374)

This pull request adds an index lifecycle management to the EBMEDS indices.

### Index Lifecycle Management
This operation was carried out in Elastic stack version 7.6.0 – current release at the time.

EBMEDS sends request payloads, triggered reminders and logs data into specific Elasticsearch indices. These indices are:
- ebmeds-request-%{YYYY.MM}
- ebmeds-reminders-%{YYYY.MM}
- ebmeds-logs-%{YYYY.MM}

The year and month are dynamically formed to the index name, so for example, `ebmeds-request-2020.03` is one possible name and so on. To control these indices in `testing` and `staging` environments, we need to apply Elasticsearch index lifecycle manager, which set the rotate rules for every index.

In the Elasticsearch and for time series indices, the index lifecycle has four stages, and they are:
- Hot: the index is actively being updated and queried.
- Warm: the index is no longer being updated, but is still being queried.
- Cold: the index is no longer being updated and is seldom queried. The information still needs to be searchable, but it is okay if those queries are slower.
- Delete: the index is no longer needed and can safely be deleted.

#### Use in testing environment
For the `testing` environment, we get along just with three phases – hot, warm and delete. All the EBMEDS indices are time series. A new entry to the index enters the `hot` stage. After 30 days it will be moved to the `warm` stage and eventually deleted when the data age reached 90 days. Long story short: data that reside in the index longer than 90 days will be deleted.

The index lifecycle management policy needs to be first created into the Elasticsearch before it can be used in the Logstash else an exception is raised. The `ebmeds-policy` can be added into the Elasticsearch followingly:

```bash
curl -X PUT "http://localhost:9200/_ilm/policy/ebmeds-index-policy?pretty" -H 'Content-Type: application/json' -d'
{
  "policy": {
    "phases": {
      "hot": {
      "min_age": "0ms",
        "actions": {
          "rollover": {
            "max_age": "30d"
          },
          "set_priority": {
            "priority": 100
          }
        }
      },
      "warm": {
        "min_age": "0ms",
        "actions": {
          "allocate": {
            "number_of_replicas": 1,
            "include": {},
            "exclude": {},
            "require": {}
          },
          "forcemerge": {
            "max_num_segments": 1
          },
          "set_priority": {
            "priority": 50
          }
        }
      },
      "delete": {
        "min_age": "60d",
        "actions": {
          "delete": {}
        }
      }
    }
  }
}
'
```

#### Advice for staging and production environment
This index lifecycle policy cannot be used in the `staging` and `production` without modification. The snapshot lifecycle must be configured for the `staging` and `production` environments before we can proceed any further. Make sure that the snapshot lifecycle is working correctly before proceeding. 

Also, make sure that everything is tested in `staging` environment and verified that they work correctly before applying index and snapshot lifecycle to the `production`.

Setting up the snapshot repository is required. Here is a simple skeleton snapshot policy of how to take snapshot daily at midnight.

```json
{
  "schedule": "0 0 * * * ?",
  "name": "ebmeds-snapshot-{now/d}",
  "repository": "<remember to configure repository>",
  "config": {
    "indices": ["*"]
  }
}
```
For more information about snapshot, please consult the links below.  Let say we name this snapshot lifecycle as `ebmeds-snapshot-policy`.

When the snapshot policy is created and running on the indices, we can proceed to set lifecycle policy for the EBMEDS indices. Following is a recommended policy to use with the EBMEDS, but further modification is required depending on the regulations.

```bash
curl -X PUT "http://localhost:9200/_ilm/policy/ebmeds-index-policy?pretty" -H 'Content-Type: application/json' -d'
{
  "policy": {
    "phases": {
      "hot": {
      "min_age": "0ms",
        "actions": {
          "rollover": {
            "max_age": "30d"
          },
          "set_priority": {
            "priority": 100
          }
        }
      },
      "warm": {
        "min_age": "0ms",
        "actions": {
          "allocate": {
            "number_of_replicas": 1,
            "include": {},
            "exclude": {},
            "require": {}
          },
          "forcemerge": {
            "max_num_segments": 1
          },
          "set_priority": {
            "priority": 50
          }
        }
      },
      "delete": {
        "min_age": "150d",
        "actions": {
	  "wait_for_snapshot" : {
            "policy": "ebmeds-snapshot-policy"
          }
          "delete": {}
        }
      }
    }
  }
}
'
```
We now set the `delete` stage to wait for the snapshot to be complete before we can proceed with deletion.

#### Further readings and information:
- [Manage the index lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/index-lifecycle-management.html)
- [Snapshot and restore](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/snapshot-restore.html)
- [Manage the snapshot lifecycle](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/snapshot-lifecycle-management.html)

**See related changes:**
- ebmeds-kubernetes: https://github.com/ebmeds/ebmeds-kubernetes/pull/4