### PR TITLE
EBMEDS-1992: Missing request and reminder log data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [EBMEDS-1992](https://jira.duodecim.fi/browse/EBMEDS-1992) Set the requestId to be a request-log document id to eliminate duplication
+
 ## V2.6.1 - 2021-01-13
 
 No changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [EBMEDS-1992](https://jira.duodecim.fi/browse/EBMEDS-1992) Set the requestId to be a request-log document id to eliminate duplication
+- [EBMEDS-1992](https://jira.duodecim.fi/browse/EBMEDS-1992) Set the Composed `requestId:logId` id for the reminder-log document id to eliminate duplication
 
 ## V2.6.1 - 2021-01-13
 

--- a/logstash/pipeline/ebmeds-reminders.conf
+++ b/logstash/pipeline/ebmeds-reminders.conf
@@ -25,6 +25,7 @@ output {
   elasticsearch {
     hosts => "elasticsearch:9200"
     index => "ebmeds-reminders-%{+YYYY.MM}"
+    document_id => "%{requestId}:%{logId}"
 
     # Set ilm_enabled value to be true
     # when ebmeds-index-policy exists in Elasticsearch.

--- a/logstash/pipeline/ebmeds-requests.conf
+++ b/logstash/pipeline/ebmeds-requests.conf
@@ -13,6 +13,7 @@ output {
   elasticsearch {
     hosts => "elasticsearch:9200"
     index => "ebmeds-requests-%{+YYYY.MM}"
+    document_id => "%{requestId}"
 
     # Set ilm_enabled value to be true
     # when ebmeds-index-policy exists in Elasticsearch.


### PR DESCRIPTION
### EBMEDS-1992

Overwrite the request and reminder log document id to abolish Elasticsearch duplicate entries.

### See related changes:
- API-Gateway: https://github.com/ebmeds/api-gateway/pull/186
- Engine: https://github.com/ebmeds/engine/pull/391
- EBMEDS-Docker: https://github.com/ebmeds/ebmeds-docker/pull/25
- EBMEDS-Kubernetes: https://github.com/ebmeds/ebmeds-kubernetes/pull/5